### PR TITLE
Fix reshape in dataset creator

### DIFF
--- a/data/load_data
+++ b/data/load_data
@@ -30,7 +30,9 @@ def create_lstm_dataset(data, shuffle = None, window_size = None, number_of_feat
         seq_x, seq_y = data.iloc[i:end_ix, :], data.iloc[end_ix, 0]
         X.append(seq_x)
         y.append(seq_y)
-    X = np.array(X).reshape(-1, number_of_features, window_size)
+    # reshape to (samples, window_size, number_of_features) as expected by most
+    # sequence models
+    X = np.array(X).reshape(-1, window_size, number_of_features)
     y = np.array(y)
     if shuffle:
         indices = np.random.permutation(len(X))


### PR DESCRIPTION
## Summary
- correct reshape order when creating LSTM datasets

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6866894966fc8323855c4113ffbfec31